### PR TITLE
Adding service reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepublishOnly": "rm tsconfig.tsbuildinfo && rm -rf out && npm run build"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.5.0",
     "@babel/code-frame": "^7.10.4",
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import JSONReporter from './reporters/json';
 import JUnitReporter from './reporters/junit';
 import LineReporter from './reporters/line';
 import ListReporter from './reporters/list';
+import ServiceReporter from './reporters/service';
 import { Multiplexer } from './reporters/multiplexer';
 import { Runner } from './runner';
 import { assignConfig, config } from './fixtures';
@@ -36,6 +37,7 @@ export const reporters = {
   'junit': JUnitReporter,
   'line': LineReporter,
   'list': ListReporter,
+  'service': ServiceReporter,
   'null': EmptyReporter,
 };
 

--- a/src/reporters/service.ts
+++ b/src/reporters/service.ts
@@ -1,0 +1,302 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import childProcess from 'child_process';
+import path from 'path';
+import { request } from 'https';
+import { EmptyReporter } from '../reporter';
+import { Config, Test, Suite, TestResult } from '../types';
+import { monotonicTime } from '../util';
+import storage, { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
+import { formatFailure, stripAscii } from './base';
+
+export type RunResult = {
+  id: string;
+  tenantId: string;
+  workflowId: string;
+  workflowName: string;
+  workflowUrl: string;
+  repo: string;
+  branch: string;
+  triggerType: string;
+  triggerId: string;
+  triggerUrl: string;
+  numTotalTestSuites: number;
+  numFailedTestSuites: number;
+  numSkippedTestSuites: number;
+  numPassedTestSuites: number;
+  numTotalTests: number;
+  numFailedTests: number;
+  numSkippedTests: number;
+  numPassedTests: number;
+  startTime: number;
+  endTime: number;
+  status: boolean;
+}
+
+export interface TestSuiteResult {
+  path: string;
+  numTotalTests: number;
+  numFailedTests: number;
+  numSkippedTests: number;
+  numPassedTests: number;
+  duration: number;
+  tests: TestCaseResult[];
+}
+
+export interface TestCaseResult {
+  name: string;
+  status: string;
+  duration: number;
+  failureMessages: string[];
+  artifacts: string[];
+}
+
+class ServiceReporter extends EmptyReporter {
+  config: Config;
+  suite: Suite;
+  private sasToken: string;
+  private blobService: BlobServiceClient;
+  private containerClient: ContainerClient;
+  private startTime: number;
+  private endTime: number;
+  private totalTestSuites = 0;
+  private failedTestSuites = 0;
+  private skippedTestSuites = 0;
+  private totalTests = 0;
+  private failedTests = 0;
+  private skippedTests = 0;
+  private artifactMap: Map<string, string[]>;
+
+  onBegin(config: Config, suite: Suite) {
+    this.config = config;
+    this.suite = suite;
+    this.sasToken = getSasToken();
+    this.startTime = monotonicTime();
+    this.blobService = new storage.BlobServiceClient(`${this.sasToken}`);
+    this.containerClient = this.blobService.getContainerClient(process.env.GITHUB_RUN_ID);
+  }
+
+  onTimeout() {
+    this.onEnd();
+  }
+
+  onTestEnd(test: Test, result: TestResult) {
+    super.onTestEnd(test, result);
+    const testOutputDir = this._getTestOutputDir(test);
+    if (fs.existsSync(testOutputDir)) {
+      const files: string[] = getAllFilesFromFolder(testOutputDir);
+      const testArtifacts: string[] = [];
+      for (const file of files) {
+        const relativePath = this._getRelativePath(file);
+        this._createBlobInContainer(file, relativePath);
+        testArtifacts.push(`${process.env.GITHUB_RUN_ID}/${relativePath}`);
+      }
+      this.artifactMap.set(this._getTestKey(test), testArtifacts);
+    }
+  }
+
+  onEnd() {
+    this.endTime = monotonicTime();
+    this._registerTestResults();
+    this._registerRunResult();
+  }
+
+  private _getTestOutputDir(test: Test): null | string {
+    const testFileName = path.relative(this.config.testDir, test.spec.file);
+    const testOutputDir = `${this.config.outputDir}/${testFileName.substring(0, testFileName.length - 8)}/${test.spec.fullTitle().replace(' ', '-')}/${test.variation['browserName']}`;
+    return testOutputDir;
+  }
+
+  private _registerTestResults() {
+    const testSuites: TestSuiteResult[] = [];
+    for (const suite of this.suite.suites) {
+      testSuites.push(this._getTestSuiteResults(suite));
+    }
+
+    const testResultsFile = `${this.config.outputDir}/testResults.json`;
+    const testResultsZippedFile = `${this.config.outputDir}/testResults.zip`;
+    fs.writeFileSync(testResultsFile, JSON.stringify(testSuites));
+    childProcess.execSync(`zip ${this.config.outputDir}/testResults ${testResultsFile}`);
+    this._createBlobInContainer(testResultsZippedFile, this._getRelativePath(testResultsZippedFile));
+  }
+
+  private _getTestSuiteResults(suite: Suite): TestSuiteResult {
+    let tests = 0;
+    let skipped = 0;
+    let failures = 0;
+    let duration = 0;
+    const testCases: TestCaseResult[] = [];
+
+    suite.findTest(test => {
+      ++tests;
+      if (test.skipped)
+        ++skipped;
+      if (!test.ok())
+        ++failures;
+      for (const result of test.results)
+        duration += result.duration;
+      this._addTestCaseResult(test, testCases);
+    });
+    this.totalTests += tests;
+    this.skippedTests += skipped;
+    this.failedTests += failures;
+
+    ++this.totalTestSuites;
+    if (tests === skipped) {
+      ++this.skippedTestSuites;
+    } else if (failures !== 0) {
+      ++this.failedTestSuites;
+    }
+
+    const testSuiteResult: TestSuiteResult = {
+      path: suite.file,
+      numTotalTests: tests,
+      numFailedTests: failures,
+      numSkippedTests: skipped,
+      numPassedTests: tests - (failures + skipped),
+      duration: duration / 1000,
+      tests: testCases
+    };
+    return testSuiteResult;
+  }
+
+  private _addTestCaseResult(test: Test, testcases: TestCaseResult[]) {
+    let status: string;
+    const failureMessages: string[] = [];
+    if (test.skipped) {
+      status = 'skipped';
+    } else if (test.ok()) {
+      status = 'passed';
+    } else {
+      status = 'failed';
+      failureMessages.push(stripAscii(formatFailure(this.config, test)));
+    }
+    let testCase: TestCaseResult = {
+      name: test.spec.fullTitle(),
+      status: status,
+      duration: (test.results.reduce((acc, value) => acc + value.duration, 0)) / 1000,
+      failureMessages: failureMessages,
+      artifacts: this.artifactMap.get(this._getTestKey(test))
+    };
+    testcases.push(testCase);
+  }
+
+  private _registerRunResult() {
+    const runResult: RunResult = {
+      id: process.env.GITHUB_RUN_ID,
+      tenantId: process.env.TENANT_ID,
+      workflowId: process.env.WORKFLOW_ID,
+      workflowName: process.env.GITHUB_WORKFLOW,
+      workflowUrl: process.env.WORKFLOW_URL,
+      repo: process.env.GITHUB_REPOSITORY,
+      branch: process.env.BRANCH_NAME,
+      triggerType: process.env.TRIGGER_TYPE,
+      triggerId: process.env.GITHUB_SHA,
+      triggerUrl: process.env.TRIGGER_URL,
+      numTotalTestSuites: this.totalTestSuites,
+      numFailedTestSuites: this.failedTestSuites,
+      numSkippedTestSuites: this.skippedTestSuites,
+      numPassedTestSuites: this.totalTestSuites - (this.failedTestSuites + this.skippedTestSuites),
+      numTotalTests: this.totalTests,
+      numFailedTests: this.failedTests,
+      numSkippedTests: this.skippedTests,
+      numPassedTests: this.totalTests - (this.failedTests + this.skippedTests),
+      startTime: this.startTime,
+      endTime: this.endTime,
+      status: this.failedTests === 0 ? true : false
+    }
+    postRunResult(runResult);
+  }
+
+  private async _createBlobInContainer(file: string, blobName: string) {
+    const blobClient = this.containerClient.getBlockBlobClient(blobName);
+    await blobClient.uploadFile(file);
+  }
+
+  private _getTestKey(test: Test): string {
+    return `${path.relative(this.config.testDir, test.spec.file)}-${test.spec.fullTitle().replace(' ', '-')}-${test.variation['browserName']}`;
+  }
+
+  private _getRelativePath(file: string): string {
+    const string = 'test-results/';
+    const baseDirIndex = file.indexOf(string);
+    return file.substring(baseDirIndex + string.length);
+  }
+}
+
+function getSasToken(): null | string {
+  let sasToken: string;
+  const options = {
+    hostname: process.env.ENDPOINT,
+    path: `api/${process.env.TENANT_ID}/sasuri?runId=${process.env.GITHUB_RUN_ID}`,
+    method: 'GET'
+  }
+
+  const req = request(options, res => {
+    res.on('data', d => {
+      sasToken = JSON.parse(d).sasUri;
+    })
+  })
+
+  req.on('error', error => {
+    console.error(error)
+  })
+  req.end()
+  return sasToken;
+}
+
+function postRunResult(runResult: RunResult) {
+  const options = {
+    hostname: process.env.ENDPOINT,
+    path: `api/${process.env.TENANT_ID}/runs`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': '*/*',
+    }
+  }
+
+  const req = request(options, res => {
+    res.on('data', d => {
+      process.stdout.write(d)
+    })
+  })
+
+  req.on('error', error => {
+    console.error(error)
+  })
+  req.write(JSON.stringify(runResult));
+  req.end()
+}
+
+function getAllFilesFromFolder(dir: string): string[] {
+  let results: string[] = [];
+
+  fs.readdirSync(dir).forEach(function (file) {
+    file = dir + '/' + file;
+    var stat = fs.statSync(file);
+
+    if (stat && stat.isDirectory()) {
+      results = results.concat(getAllFilesFromFolder(file))
+    } else results.push(file);
+
+  });
+  return results;
+}
+
+export default ServiceReporter;

--- a/test/service-reporter.spec.ts
+++ b/test/service-reporter.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { folio } from './fixtures';
+ const { it, expect } = folio;
+ 
+ it('should support spec.ok', async ({ runInlineTest }) => {
+   // TODO: Add tests
+ });
+ 

--- a/test/service-reporter.spec.ts
+++ b/test/service-reporter.spec.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
- import { folio } from './fixtures';
- const { it, expect } = folio;
- 
- it('should support spec.ok', async ({ runInlineTest }) => {
-   // TODO: Add tests
- });
- 
+import { folio } from './fixtures';
+const { it, expect } = folio;
+
+it('should support spec.ok', async ({ runInlineTest }) => {
+  // TODO: Add tests
+});


### PR DESCRIPTION
This PR adds the reporter in folio for the Playwright service.

The actions needed through the reporter are:
- Create Run resource for the workflow run
- Get Sas token for the run container, upload test artifacts
- Upload test result file to the run container

The structure of the RunResult, TestSuiteResult and TestCaseResult types is analogous to the same types developed as part of [jest-playwright-reporter](https://github.com/pratiksharma23/jest-playwright-reporter/tree/ps.cleanup_files).

Since [request](https://github.com/request/request) is now in maintenance mode (https://github.com/request/request/issues/3142), shall we use an alternative (https://github.com/request/request/issues/3143) for making http/https requests?